### PR TITLE
refactor(e2e): 定数を helpers/constants.ts に集約

### DIFF
--- a/e2e/helpers/constants.ts
+++ b/e2e/helpers/constants.ts
@@ -1,0 +1,47 @@
+/**
+ * E2Eテスト用の定数定義
+ */
+
+/**
+ * 添付ファイルフィールドのコードとラベルのマッピング
+ */
+export const ATTACHMENT_FIELDS = {
+  attachment1: {
+    code: "attachment1",
+    label: "添付ファイル1",
+  },
+  attachment2: {
+    code: "attachment2",
+    label: "添付ファイル2",
+  },
+} as const;
+
+/**
+ * フィールドコードからラベルを取得する
+ */
+export const getFieldLabel = (
+  fieldCode: keyof typeof ATTACHMENT_FIELDS
+): string => {
+  return ATTACHMENT_FIELDS[fieldCode].label;
+};
+
+/**
+ * 全フィールドコードの配列を取得する
+ */
+export const getAllFieldCodes = (): string[] => {
+  return Object.keys(ATTACHMENT_FIELDS);
+};
+
+/**
+ * テスト用のタイムアウト値
+ */
+export const TIMEOUTS = {
+  /** 要素表示待機 */
+  ELEMENT_VISIBLE: 10000,
+  /** ページ遷移待機 */
+  PAGE_NAVIGATION: 30000,
+  /** 保存完了待機 */
+  SAVE_COMPLETE: 10000,
+  /** モーダル非表示待機 */
+  MODAL_HIDDEN: 5000,
+} as const;


### PR DESCRIPTION
## Summary
- E2Eテスト用の定数ファイル `e2e/helpers/constants.ts` を新規作成
- 添付ファイルフィールドのマッピング（`ATTACHMENT_FIELDS`）を定義
- タイムアウト値（`TIMEOUTS`）を一元管理

## Test plan
- [ ] TypeScriptの型チェックが通ることを確認

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)