### PR TITLE
docs: test.mdにStorybookの確認方法を追加

### DIFF
--- a/rules/guidelines/test.md
+++ b/rules/guidelines/test.md
@@ -25,6 +25,11 @@
 - UI/Pages は storybook を利用し、コンポーネントの操作が意図的かを常に人間が確認できる状態に**必ず**しておく
   - storybook においても story は必要最低限にする
 
+#### Storybook の確認方法
+
+- Storybook の確認には `pnpm storybook` を利用し、ビルド（`pnpm build-storybook`）はしない
+- AI エージェントが Storybook を確認する際は Playwright MCP を利用して確認する
+
 ### hooks/
 
 - hooks/配下のカスタムフックはテストを必要としない


### PR DESCRIPTION
## Summary
- `rules/guidelines/test.md` の「UI/Pages 層」セクションにStorybookの確認方法を追加
- 開発時は `pnpm storybook` を使用（ビルド不要）
- AIエージェントは Playwright MCP で確認することを明記

## Test plan
- [ ] ドキュメントの内容が正しく反映されていることを確認

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)